### PR TITLE
Use maintainers instead of BFDL

### DIFF
--- a/src/overview/developers.md
+++ b/src/overview/developers.md
@@ -5,7 +5,7 @@ We are quite a few developers at Redox. 40+ people work on it. There are all sor
 
 Our BDFL is Jeremy Soller (Jackpot51), who maintains the kernel, Orbital (and OrbTK), and the overall direction of the project.
 
-The other side projects have different BDFLs:
+The other side projects have different maintainers:
 
 - Ion: Skyler Berg.
 - Sodium: Ticki.


### PR DESCRIPTION
You asked for nitpicking, so here I go :). BFDL should only be used for
large projects that have been around for a while and have an established
leader who no one could every see changing. The side projects are likely
to have their maintainers change and are not so large as to warrant
calling anyone a BFDL.