### PR TITLE
Fixed: Removed compiling section with extra commands

### DIFF
--- a/src/getting_started/compiling_redox.md
+++ b/src/getting_started/compiling_redox.md
@@ -12,18 +12,6 @@ $ git clone https://github.com/redox-os/redox.git && cd redox && git submodule u
 
 Give it a while. Redox is big.
 
-Yay! Building!
---------------
-
-```sh
-$ cd /path/to/redox
-$ make -j 4 build
-```
-
-This is going to take a while. So sit down and relax.
-
-When this is done, the exciting part is starting:
-
 Running Redox
 -------------
 


### PR DESCRIPTION
Compiling and running Redox-Os require the same commands