### PR TITLE
Spaces after identifier

### DIFF
--- a/src/userspace/ion/the_syntax.md
+++ b/src/userspace/ion/the_syntax.md
@@ -12,7 +12,7 @@ echo 'This is the first line'; echo 'This is the second line'
 let identifier = "Some string"
 
 # Note that spaces between the identifier and value are optional:
-let identifier = "Some string"
+let identifier="Some string"
 
 # Using the variable:
 echo $identifier    # stdout: `Some string`


### PR DESCRIPTION
In the note above the example code there is an indication that the spaces are optional.
The example was kept the same, updated the example to remove spaces.
Hopefully I understood the note, please check if this is the intended behaviour.