### PR TITLE
Updating macOS cross compilers

### DIFF
--- a/src/getting_started/preparing_the_build.md
+++ b/src/getting_started/preparing_the_build.md
@@ -49,8 +49,7 @@ MacOS Users using Homebrew:
 
 ```
 $ brew install make nasm qemu gcc49 pkg-config Caskroom/cask/osxfuse
-$ brew tap glendc/gcc_cross_compilers
-$ brew install glendc/gcc_cross_compilers/x64-elf-binutils glendc/gcc_cross_compilers/x64-elf-gcc
+$ brew install redox-os/gcc_cross_compilers/x86_64-elf-gcc
 ```
 
 Setting Up Nightly Rust


### PR DESCRIPTION
In section 3.1 'Preparing Redox', the book suggests using the cross compilers from glendc/gcc_cross_compilers. These no longer work, and are not being used in the bootstrap.sh script from the redox-os/redox repo. This closes redox-os/book#84.