### PR TITLE
fix chapter name in SUMMARY.md

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -59,7 +59,7 @@
     - [Trade-offs]()
         - [Safety and performance]()
         - [Simplicity and expressiveness]()
-    - [Programs and Libraries](./design/programs.md)
+    - [Programs and Libraries](./design/programs_libraries.md)
     - [Coreutils](./design/coreutils/coreutils.md)
         - [Fail, fail, and fail]()
         - [Simplicty and minimalism]()


### PR DESCRIPTION
The "Programs and Libraries" link in TOC doesn't work, this should fix it.