### PR TITLE
Update outdated URLs

### DIFF
--- a/src/overview/maintainers.md
+++ b/src/overview/maintainers.md
@@ -19,7 +19,7 @@ Currently, [jackpot51] maintains:
 - [Extrautils]
 - [The project "Games for Redox"]
 - [Libextra]
-- [Libmalloc]
+- [Ralloc]
 - [Sodium]
 - [TFS, an implementation of ZFS]
 
@@ -39,7 +39,7 @@ Currently, [jackpot51] maintains:
 [Orbutils]: https://github.com/redox-os/orbutils
 [pkgutils]: https://github.com/redox-os/pkgutils
 
-[Libmalloc]: https://github.com/redox-os/libmalloc
+[Ralloc]: https://github.com/redox-os/ralloc
 [Coreutils]: https://github.com/redox-os/coreutils
 [Sodium]: https://github.com/redox-os/sodium
 [TFS, an implementation of ZFS]: https://github.com/redox-os/tfs
@@ -47,6 +47,6 @@ Currently, [jackpot51] maintains:
 [Libextra]: https://github.com/redox-os/libextra
 [Binutils]: https://github.com/redox-os/binutils
 [Extrautils]: https://github.com/redox-os/extrautils
-[The project "Games for Redox"]: https://github.com/redox-os/games-for-redox
+[The project "Games for Redox"]: https://github.com/redox-os/games
 
 [Ion Shell]: https://github.com/redox-os/ion

--- a/src/overview/side_projects.md
+++ b/src/overview/side_projects.md
@@ -36,7 +36,7 @@ The first category should be obvious: an OS without certain core tools is a usel
 
 It is important to note we seek to avoid non-Rust tools, for safety and consistency (see [Why Rust]).
 
-[TFS]: https://github.com/ticki/tfs
+[TFS]: https://github.com/redox-os/tfs
 [Ion]: https://github.com/redox-os/ion
 [Orbital]: https://github.com/redox-os/orbital
 [OrbTK]: https://github.com/redox-os/orbtk

--- a/src/overview/what_redox_is.md
+++ b/src/overview/what_redox_is.md
@@ -31,7 +31,7 @@ It is written such that you do not need any prior knowledge in Rust and/or OS de
 
 [Rust]:  https://www.rust-lang.org  
 [POSIX]: https://en.wikipedia.org/wiki/POSIX
-[Plan9]: http://plan9.bell-labs.com/plan9/index.html
+[Plan9]: http://9p.io/plan9/index.html
 [Minix]: http://www.minix3.org/
 [Linux]: https://en.wikipedia.org/wiki/Linux
 [BSD]: http://www.bsd.org/


### PR DESCRIPTION
While reading the book, I noticed the link to Plan9 was broken. It appears that the original website is down indefinitely. I confirmed in the #plan9 channel on freenode that the mirror at 9p.io is considered the canonical site for the project now (see screenshot for IRC conversation).

While I was at it, I updated a couple other links that have moved permanently (libmalloc -> ralloc and tfs).

There are two other broken links: the links to https://github.com/EGhiorzi (appears [here](https://github.com/redox-os/book/blob/master/src/getting_started/exploring_redox.md) and [here](https://github.com/redox-os/book/blob/master/src/overview/community.md)), but I don't know what those URLs should be to fix them.

![screenshot-2017-10-30 plan9 - freenode web irc](https://user-images.githubusercontent.com/1614172/32194441-6c846c64-bd88-11e7-8cb8-c46bec320833.png)
