### PR TITLE
added cmake dependency

### DIFF
--- a/src/getting_started/preparing_the_build.md
+++ b/src/getting_started/preparing_the_build.md
@@ -36,7 +36,7 @@ I assume you have a package manager, which you know how to use (if not, you have
 Linux Users:
 
 ```
-$ [your package manager] install make nasm qemu pkg-config libfuse-dev
+$ [your package manager] install cmake make nasm qemu pkg-config libfuse-dev
 ```
 
 MacOS Users using MacPorts:


### PR DESCRIPTION
I didn't have cmake installed on arch, and my build failed. Thought it should be included in the book