### PR TITLE
Various updates and fixes

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -109,7 +109,7 @@
         - [Reddit](./contributing/communication/reddit.md)
     - [Direct contributions]()
         - [Low hanging fruit](./contributing/direct_contributions/low_hanging_fruit.md)
-        - [Github issues](./contributing/direct_contributions/github_issues.md)
+        - [GitHub issues](./contributing/direct_contributions/github_issues.md)
             - [How to do a bug report correctly](./contributing/direct_contributions/creating_proper_bug_reports.md)
         - [Pull requests](./contributing/direct_contributions/pull_requests.md)
             - [How to do a pull request properly](./contributing/direct_contributions/creating_proper_pull_requests.md)

--- a/src/contributing/best_practices/rusting_properly.md
+++ b/src/contributing/best_practices/rusting_properly.md
@@ -3,7 +3,6 @@
 Some general guidelines:
 
 * Use `std::mem::replace` and `std::mem::swap` when you can.
-* `libredox` should be 1-to-1 with the official `libstd`.
 * Use `.into()` and `.to_owned()` over `.to_string()`.
 * Prefer passing references to the data over owned data. (Don't take `String`, take `&str`. Don't take `Vec<T>` take `&[T]`).
 * Use generics, traits, and other abstractions Rust provides.

--- a/src/contributing/direct_contributions/creating_proper_bug_reports.md
+++ b/src/contributing/direct_contributions/creating_proper_bug_reports.md
@@ -11,8 +11,8 @@
     * `qemu-system-x86_64 -version` or your actual hardware specs, if applicable
   * The operating system you used to build Redox
     * `uname -a` or an alternative format
-4. Make sure that your bug doesn't already have an issue on Github. If you submit a duplicate, you should accept that you may be ridiculed for it, though you'll still be helped. Feel free to ask in the Redox [chat](./contributing/communication/chat.html) if you're uncertain as to whether your issue is new
-5. Create a Github issue following the template
+4. Make sure that your bug doesn't already have an issue on GitHub. If you submit a duplicate, you should accept that you may be ridiculed for it, though you'll still be helped. Feel free to ask in the Redox [chat](./contributing/communication/chat.html) if you're uncertain as to whether your issue is new
+5. Create a GitHub issue following the template
     * Non-bug report issues may ignore this template
 6. Watch the issue and be available for questions
 7. Success!

--- a/src/contributing/direct_contributions/github_issues.md
+++ b/src/contributing/direct_contributions/github_issues.md
@@ -1,5 +1,5 @@
 # GitHub Issues
 
-Github issues are a somewhat formal way to communicate with fellow Redox devs, but a little less quick and convenient than the chat. Issues are a good way to discuss specific topics, but if you want a quick response, using the chat is probably better.
+GitHub issues are a somewhat formal way to communicate with fellow Redox devs, but a little less quick and convenient than the chat. Issues are a good way to discuss specific topics, but if you want a quick response, using the chat is probably better.
 
 If you haven't requested to join the chat yet, you should (if at all interested in contributing)!

--- a/src/design/kernel/microkernels.md
+++ b/src/design/kernel/microkernels.md
@@ -25,7 +25,7 @@ The above illustration ([from Wikimedia], by Wooptoo, License: Public domain) sh
 A note on the current state
 ---------------------------
 
-Redox has less then 9,000 lines of kernel code. For comparison Minix has ~6,000 lines of kernel code.
+Redox has less than 9,000 lines of kernel code. For comparison Minix has ~6,000 lines of kernel code.
 
 We would like to move parts of Redox to user space to get an even smaller kernel.
 

--- a/src/design/programs_libraries.md
+++ b/src/design/programs_libraries.md
@@ -5,7 +5,7 @@ Redox can run programs. Some programs are interpreted by a runtime for the progr
 * In Redox compiled binaries use the standard [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) ("Executable and Linkable Format") format.
 
 Programs could directly invoke Redox syscalls, but most call library functions that are higher-level and more comfortable to use. You link your program with the libraries it needs.
-* Redox does not support dynamic-link libraries yet *(issue #927)*, so the libraries that a program uses are statically linked into its compiled binary.
+* Redox does not support dynamic-link libraries yet ([issue #927](https://github.com/redox-os/redox/issues/927)), so the libraries that a program uses are statically linked into its compiled binary.
 * Most C and C++ programs call functions in a [C standard library](https://en.wikipedia.org/wiki/C_standard_library) ("libc") such as `fopen`
   * Redox includes a port of the newlib Standard C library. This is how programs such as git can run on Redox. newlib has some POSIX compatibility.
 * Rust programs implicitly or explicitly call functions in the Rust standard library (libstd).

--- a/src/design/scheme/schemes.md
+++ b/src/design/scheme/schemes.md
@@ -52,11 +52,6 @@ The kernel provides a small number of schemes in order to support userspace.
         <td><a href="https://doc.redox-os.org/kernel/kernel/scheme/irq/index.html">Docs</a></td>
     </tr>
     <tr>
-        <td><code>null:</code></td>
-        <td>Scheme that will discard all writes, and read no bytes</td>
-        <td><a href="https://doc.redox-os.org/kernel/kernel/scheme/null/index.html">Docs</a></td>
-    </tr>
-    <tr>
         <td><code>pipe:</code></td>
         <td>Used internally by the kernel to implement <code>pipe</code></td>
         <td><a href="https://doc.redox-os.org/kernel/kernel/scheme/pipe/index.html">Docs</a></td>
@@ -65,11 +60,6 @@ The kernel provides a small number of schemes in order to support userspace.
         <td><code>sys:</code></td>
         <td>System information, such as the context list and scheme list</td>
         <td><a href="https://doc.redox-os.org/kernel/kernel/scheme/sys/index.html">Docs</a></td>
-    </tr>
-    <tr>
-        <td><code>zero:</code></td>
-        <td>Scheme that will discard all writes, and always fill read buffers with zeroes</td>
-        <td><a href="https://doc.redox-os.org/kernel/kernel/scheme/zero/index.html">Docs</a></td>
     </tr>
 </table>
 
@@ -115,6 +105,11 @@ The Redox userspace, starting with initfs:bin/init, will create schemes during i
         <td>Link level network send/receive, used by <code>ethernet:</code></td>
     </tr>
     <tr>
+        <td><code>null:</code></td>
+        <td><code>nulld</code></td>
+        <td>Scheme that will discard all writes, and read no bytes</td>
+    </tr>
+    <tr>
         <td><code>orbital:</code></td>
         <td><code>orbital</code></td>
         <td>Windowing system</td>
@@ -138,6 +133,11 @@ The Redox userspace, starting with initfs:bin/init, will create schemes during i
         <td><code>udp:</code></td>
         <td><code>udpd</code></td>
         <td>UDP sockets</td>
+    </tr>
+    <tr>
+        <td><code>zero:</code></td>
+        <td><code>zerod</code></td>
+        <td>Scheme that will discard all writes, and always fill read buffers with zeroes</td>
     </tr>
 </table>
 

--- a/src/getting_started/compiling_redox.md
+++ b/src/getting_started/compiling_redox.md
@@ -37,4 +37,6 @@ If this doesn't work either, you should go open an issue.
 Note
 ----
 
-If you encounter any bugs, errors, obstructions, or other annoying things, please report the issue to the Redox repository. Thanks!
+If you encounter any bugs, errors, obstructions, or other annoying things, please report the issue to the [Redox repository]. Thanks!
+
+[Redox repository]: https://github.com/redox-os/redox

--- a/src/getting_started/exploring_redox.md
+++ b/src/getting_started/exploring_redox.md
@@ -1,9 +1,9 @@
 Exploring Redox
 ===============
 
-Use F2 or F3 keys to get to a login shell. User `user` can login without password. For `root`, the password is `password` for now. `help` lists builtin commands for your shell (ion). `ls /bin` will show a list of applications you can execute.
+Use F2 key to get to a login shell. User `user` can login without password. For `root`, the password is `password` for now. `help` lists builtin commands for your shell (ion). `ls /bin` will show a list of applications you can execute.
 
-Use F4 key to switch to a graphical user interface (orbital). Log in with the same username/password combinations as above.
+Use F3 key to switch to a graphical user interface (orbital). Log in with the same username/password combinations as above.
 
 Use the F1 key to get back to kernel output.
 

--- a/src/getting_started/preparing_the_build.md
+++ b/src/getting_started/preparing_the_build.md
@@ -12,7 +12,7 @@ If you're on a Linux or macOS computer, you can just run the bootstrapping scrip
 $ curl -sf https://raw.githubusercontent.com/redox-os/redox/master/bootstrap.sh -o bootstrap.sh && bash -e bootstrap.sh
 ```
 
-This script fetches build dependencies using a package manager for your platform and clones the Redox code from Github. It checks whether you might already have a dependency and skips the installation in this case. On some systems this is simply done by checking whether the binary exists and doesn't take into account which version of the program you have. This can lead to build errors if you have old versions already installed. In this case, please install the skipped dependencies manually.
+This script fetches build dependencies using a package manager for your platform and clones the Redox code from GitHub. It checks whether you might already have a dependency and skips the installation in this case. On some systems this is simply done by checking whether the binary exists and doesn't take into account which version of the program you have. This can lead to build errors if you have old versions already installed. In this case, please install the skipped dependencies manually.
 
 Manual Setup
 ------------

--- a/src/introduction/about_this_book.md
+++ b/src/introduction/about_this_book.md
@@ -1,8 +1,8 @@
 About this Book
 ===============
 
-This book is written in [markdown], built using [mdbook]. The source files can be found (and forked) on github at [github.com/redox-os/book/].
+This book is written in [Markdown], built using [mdBook]. The source files can be found (and forked) on GitHub at [github.com/redox-os/book/].
 
-[markdown]: http://daringfireball.net/projects/markdown/basics
-[mdbook]: https://github.com/azerupi/mdBook
+[Markdown]: http://daringfireball.net/projects/markdown/basics
+[mdBook]: https://github.com/azerupi/mdBook
 [github.com/redox-os/book/]: https://github.com/redox-os/book/

--- a/src/introduction/why_free_software.md
+++ b/src/introduction/why_free_software.md
@@ -12,7 +12,7 @@ Free Software is more Secure
 Redox OS is predominately MIT X11-style licensed, including all software, documentation, and fonts. There are only a few exceptions to this:
 - GNU Unifont, which is GPLv2
 - Fira font, which is SIL Open Font License 1.1
-- Oxygen icons from KDE, which are LGPLv3
+- Faba and Moka icons, which are GPLv3
 - Newlib C library, [which is a number of free software licenses, mostly BSD](https://github.com/bminor/newlib/blob/master/COPYING.NEWLIB)
 - NASM, which is BSD 2-clause
 

--- a/src/introduction/why_redox.md
+++ b/src/introduction/why_redox.md
@@ -43,8 +43,8 @@ The Need for Something New
 We have to admit, that we do like the idea of writing something that is our own (Not Invented Here syndrome). There are numerous places in the MINIX 3 source code where we would like to make changes, so many that perhaps a rewrite in Rust makes the most sense.
 
 - Different VFS model, based on URLs, where a program can control an entire segmented filesystem
-- Different driver model, where drivers interface with filesystems like network: and audio: to provide features
-- Different file system, RedoxFS, with a ZFS implementation in progress
+- Different driver model, where drivers interface with filesystems like `network:` and `audio:` to provide features
+- Different file system, RedoxFS, with a [TFS] implementation in progress
 - User space written mostly in Rust
 - Orbital, a new GUI
 
@@ -52,3 +52,4 @@ We have to admit, that we do like the idea of writing something that is our own 
 [jails]: https://www.freebsd.org/doc/handbook/jails.html
 [ZFS]: https://www.freebsd.org/doc/handbook/zfs.html
 [reliability]: http://wiki.minix3.org/doku.php?id=www:documentation:reliability
+[TFS]: https://github.com/redox-os/tfs

--- a/src/overview/community.md
+++ b/src/overview/community.md
@@ -8,42 +8,54 @@ The "core team" (people who are members of the [GitHub organization](https://git
 (alphabetically sorted)
 
 - [alicemaz]
-- [eghiorzi]
+- [arcterus]
+- [aurelien-git]
+- [batonius]
+- [ca1ek]
+- [cwood1]
+- [dlrobertson]
 - [hauleth]
-- [henrikhodne]
+- [ids1024]
 - [jackpot51] (who is our [BDFL])
 - [k0pernicus]
 - [mgattozzi]
 - [mmstick]
+- [movingtomars]
 - [nounoursheureux]
 - [polymetric1]
-- [roxxik]
+- [pythoneer]
+- [sajattack]
 - [skylerberg]
 - [stratact]
-- [tedsta]
 - [ticki]
 
-Some of those developers maintain several projects.  
-If you are looking to contribute to a project, you can contact the developer who is responsible that maintain the project using [this list]. 
+Some of those developers maintain several projects.
+If you are looking to contribute to a project, you can contact the developer who is responsible that maintain the project using [this list].
 
 But [don't]. [forget]. [all]. [the]. [other]. [awesome]. [contributors].
 
 [BDFL]: https://en.wikipedia.org/wiki/Benevolent_dictator_for_life
 
 [alicemaz]: https://github.com/alicemaz
-[eghiorzi]: https://github.com/eghiorzi
+[arcterus]: https://github.com/arcterus
+[aurelien-git]: https://github.com/aurelien-git
+[batonius]: https://github.com/batonius
+[ca1ek]: https://github.com/ca1ek
+[cwood1]: https://github.com/cwood1
+[dlrobertson]: https://github.com/dlrobertson
 [hauleth]: https://github.com/hauleth
-[henrikhodne]: https://github.com/henrikhodne
+[ids1024]: https://github.com/ids1024
 [jackpot51]: https://github.com/jackpot51
 [k0pernicus]: https://github.com/k0pernicus
 [mgattozzi]: https://github.com/mgattozzi
 [mmstick]: https://github.com/mmstick
+[movingtomars]: https://github.com/movingtomars
 [nounoursheureux]: https://github.com/nounoursheureux
 [polymetric1]: https://github.com/polymetric1
-[roxxik]: https://github.com/roxxik
+[pythoneer]: https://github.com/pythoneer
+[sajattack]: https://github.com/sajattack
 [skylerberg]: https://github.com/skylerberg
 [stratact]: https://github.com/stratact
-[tedsta]: https://github.com/tedsta
 [ticki]: https://github.com/ticki
 
 [this list]: ./overview/maintainers.html

--- a/src/overview/maintainers.md
+++ b/src/overview/maintainers.md
@@ -21,12 +21,12 @@ Currently, [jackpot51] maintains:
 - [Libextra]
 - [Ralloc]
 - [Sodium]
-- [TFS, an implementation of ZFS]
+- [TFS, a next-generation file system]
 
-[skylerberg] maintains the [Ion Shell].
+[mmstick] maintains the [Ion Shell].
 
 [jackpot51]: https://github.com/jackpot51
-[skylerberg]: https://github.com/skylerberg
+[mmstick]: https://github.com/mmstick
 [stratact]: https://github.com/stratact
 [ticki]: https://github.com/ticki
 
@@ -42,7 +42,7 @@ Currently, [jackpot51] maintains:
 [Ralloc]: https://github.com/redox-os/ralloc
 [Coreutils]: https://github.com/redox-os/coreutils
 [Sodium]: https://github.com/redox-os/sodium
-[TFS, an implementation of ZFS]: https://github.com/redox-os/tfs
+[TFS, a next-generation file system]: https://github.com/redox-os/tfs
 [Tedsta]: https://github.com/tedsta
 [Libextra]: https://github.com/redox-os/libextra
 [Binutils]: https://github.com/redox-os/binutils

--- a/src/overview/what_redox_is.md
+++ b/src/overview/what_redox_is.md
@@ -9,10 +9,11 @@ We take inspiration from [Plan9], [Minix], [Linux], and [BSD]. We are trying to 
 
 At this time, Redox supports:
 
-* All x86_64 CPUs.  
-* Graphics cards with VBE support (all nvidia, intel, and amd cards from the past decade have this).  
-* AHCI disks.  
-* E1000 or RTL8168 network cards.  
+* All x86-64 CPUs.
+* Graphics cards with VBE support (all Nvidia, Intel, and AMD cards from the past decade have this).
+* AHCI disks.
+* E1000 or RTL8168 network cards.
+* Intel HDA audio controllers.
 * Mouse and keyboard with PS/2 emulation.
 
 This book is broken into 9 parts:
@@ -29,7 +30,7 @@ This book is broken into 9 parts:
 
 It is written such that you do not need any prior knowledge in Rust and/or OS development.
 
-[Rust]:  https://www.rust-lang.org  
+[Rust]:  https://www.rust-lang.org
 [POSIX]: https://en.wikipedia.org/wiki/POSIX
 [Plan9]: http://9p.io/plan9/index.html
 [Minix]: http://www.minix3.org/


### PR DESCRIPTION
* Fix spelling: github -> GitHub, etc.
* Update the GitHub team list
* Move `null:` and `zero:` to the userspace schemes
* Change icons from Oxygen to Faba/Moka
* Remove statements that TFS is a ZFS implementation
* Add Intel HDA to the supported hardware
* Remove the `libredox` guideline
* Add some outgoing links where I think they're necessary