### PR TITLE
Fix "preparing the build" chapter linking back to a previous chapter as next step

### DIFF
--- a/src/getting_started/installing_the_toolchain.md
+++ b/src/getting_started/installing_the_toolchain.md
@@ -66,4 +66,4 @@ To install the toolchain, run the following commands:
 Next steps
 ----------
 
-Now that we have the build tools and the toolchain, we can finally [compile Redox](getting_started/compiling_redox.html)
+Now that we have the build tools and the toolchain, we can [prepare our build](getting_started/preparing_the_build.html).

--- a/src/getting_started/preparing_the_build.md
+++ b/src/getting_started/preparing_the_build.md
@@ -73,4 +73,4 @@ $ cargo install xargo
 Next steps
 ----------
 
-Once this is all set up, you can move on to [installing the toolchain](getting_started/installing_the_toolchain.html).
+Once this is all set up, we can finally [compile Redox](getting_started/compiling_redox.html).


### PR DESCRIPTION
As pointed out in #122, the chapter "preparing the build" says the next step is to install the toolchain, which is the previous chapter, while "install the toolchain" is skipping "preparing the build" and going straight to "compiling Redox".

This can be confusing for readers, so I changed the links in the "next step" paragraph to follow the order of the chapters.

