### PR TITLE
it's on the Mozilla network, not Freenode (in case people assume that)

### DIFF
--- a/src/contributing/chat.md
+++ b/src/contributing/chat.md
@@ -4,4 +4,4 @@ Chat
 The quickest and most open way to communicate with the Redox team is on our chat server, powered with [Mattermost](https://about.mattermost.com/).
 Currently, the only way to join it is by sending an email to [info@redox-os.org](mailto:info@redox-os.org), which might take a little while, since it's not automated. We're currently working on an easier way to do this, but this is the most convenient way right now.
 
-The Redox team is also available on IRC, on the `#redox` and `#rust` channels, but be advertised that we are less present on IRC than the Chat.
+The Redox team is also available on IRC, on the `#redox` and `#rust` channels on the Mozilla network, but be advertised that we are less present on IRC than the Chat.


### PR DESCRIPTION
Mentioning that it is the Mozilla network that the IRC channels are on. I assumed it may have been Freenode and others may do the same, so I thought it would be good to mention that it is the Mozilla network where the IRC channels are located.